### PR TITLE
Fix the build fails to link on macOS Sierra.

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -180,11 +180,18 @@ fn main() {
     // Print the appropriate linker flags
     let out_dir = env::var("OUT_DIR").ok().expect("OUT_DIR missing");
     let linker_flags = if have_snappy {
-        "-l static=snappy -l static=leveldb -l stdc++"
+        "-l static=snappy -l static=leveldb"
     } else {
-        "-l static=leveldb -l stdc++"
+        "-l static=leveldb"
     };
-    println!("cargo:rustc-flags=-L native={} {} -l stdc++", out_dir, linker_flags);
+    println!("cargo:rustc-flags=-L native={} {}", out_dir, linker_flags);
+
+    let target = env::var("TARGET").unwrap();
+    if target.contains("apple") {
+        println!("cargo:rustc-link-lib=c++");
+    } else {
+        println!("cargo:rustc-link-lib=stdc++");
+    }
 
     println!("[build] Finished");
 }


### PR DESCRIPTION
By following things, we should use libc++ on macOS.

- If we uses libstdc++ (`-l stdc++`), the build is failed on macOS Sierra (10.12).
- OSX Lion (10.7) or later can use libc++ (`-l c++`) and this avoid
  the build failuare on macOS Sierra.