### PR TITLE
Add support to correctly build on FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ leveldb-sys = "*"
 ## LICENSE
 
 MIT
+
+## FreeBSD support
+
+To build leveldb-sys you need to install `gmake` (GNU Make)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ leveldb-sys = "*"
 
 MIT
 
-## FreeBSD support
+## BSD support
 
 To build leveldb-sys you need to install `gmake` (GNU Make)

--- a/src/build.rs
+++ b/src/build.rs
@@ -13,15 +13,16 @@ const SNAPPY_VERSION: &'static str  = "1.1.2";
 const LEVELDB_VERSION: &'static str = "1.18";
 
 
-fn build_snappy() {
+fn build_snappy(is_freebsd: bool) {
     // Step 1: Build snappy
     // ----------------------------------------------------------------------
     let snappy_path = Path::new("deps")
                            .join(format!("snappy-{}", SNAPPY_VERSION));
+    let make = if is_freebsd { "gmake" } else { "make" };
 
     // Clean the build directory first.
     println!("[snappy] Cleaning");
-    Command::new("make").args(&["-C", snappy_path.to_str().unwrap()])
+    Command::new(make).args(&["-C", snappy_path.to_str().unwrap()])
                         .arg("distclean")
                         .status().ok().expect("make distclean failed");
 
@@ -33,7 +34,7 @@ fn build_snappy() {
 
     // Call "make" to build the C library
     println!("[snappy] Building");
-    Command::new("make").args(&["-C", snappy_path.to_str().unwrap()])
+    Command::new(make).args(&["-C", snappy_path.to_str().unwrap()])
                         .status().ok().expect("make failed");
 
     // Step 2: Copy to output directories
@@ -46,15 +47,16 @@ fn build_snappy() {
     res.ok().expect("copy of output files failed");
 }
 
-fn build_leveldb(with_snappy: bool) {
+fn build_leveldb(with_snappy: bool, is_freebsd: bool) {
     // Step 1: Build LevelDB
     // ----------------------------------------------------------------------
     let leveldb_path = Path::new("deps")
                             .join(format!("leveldb-{}", LEVELDB_VERSION));
+    let make = if is_freebsd { "gmake" } else { "make" };
 
     // Clean the build directory first.
     println!("[leveldb] Cleaning");
-    Command::new("make").args(&["-C", leveldb_path.to_str().unwrap()])
+    Command::new(make).args(&["-C", leveldb_path.to_str().unwrap()])
                         .arg("clean")
                         .status().ok().expect("clean failed");
 
@@ -88,7 +90,7 @@ fn build_leveldb(with_snappy: bool) {
         );
     }
 
-    let mut cmd = Command::new("make");
+    let mut cmd = Command::new(make);
 
     println!("[leveldb] Building command");
 
@@ -119,10 +121,11 @@ fn main() {
     println!("[build] Started");
 
     let have_snappy = env::var("CARGO_FEATURE_SNAPPY").is_ok();
+    let is_freebsd = env::var("TARGET").unwrap().ends_with("freebsd");
 
     // If we have the appropriate feature, then we build snappy.
     if have_snappy {
-        build_snappy();
+        build_snappy(is_freebsd);
     }
 
     // Copy the build_detect_platform file into the appropriate place.
@@ -175,7 +178,7 @@ fn main() {
     fs::set_permissions(&detect_path, perms).ok().expect("permissions could not be set");
 
     // Build LevelDB
-    build_leveldb(have_snappy);
+    build_leveldb(have_snappy, is_freebsd);
 
     // Print the appropriate linker flags
     let out_dir = env::var("OUT_DIR").ok().expect("OUT_DIR missing");

--- a/src/build.rs
+++ b/src/build.rs
@@ -13,12 +13,12 @@ const SNAPPY_VERSION: &'static str  = "1.1.2";
 const LEVELDB_VERSION: &'static str = "1.18";
 
 
-fn build_snappy(is_freebsd: bool) {
+fn build_snappy(is_bsd: bool) {
     // Step 1: Build snappy
     // ----------------------------------------------------------------------
     let snappy_path = Path::new("deps")
                            .join(format!("snappy-{}", SNAPPY_VERSION));
-    let make = if is_freebsd { "gmake" } else { "make" };
+    let make = if is_bsd { "gmake" } else { "make" };
 
     // Clean the build directory first.
     println!("[snappy] Cleaning");
@@ -47,12 +47,12 @@ fn build_snappy(is_freebsd: bool) {
     res.ok().expect("copy of output files failed");
 }
 
-fn build_leveldb(with_snappy: bool, is_freebsd: bool) {
+fn build_leveldb(with_snappy: bool, is_bsd: bool) {
     // Step 1: Build LevelDB
     // ----------------------------------------------------------------------
     let leveldb_path = Path::new("deps")
                             .join(format!("leveldb-{}", LEVELDB_VERSION));
-    let make = if is_freebsd { "gmake" } else { "make" };
+    let make = if is_bsd { "gmake" } else { "make" };
 
     // Clean the build directory first.
     println!("[leveldb] Cleaning");
@@ -121,11 +121,11 @@ fn main() {
     println!("[build] Started");
 
     let have_snappy = env::var("CARGO_FEATURE_SNAPPY").is_ok();
-    let is_freebsd = env::var("TARGET").unwrap().ends_with("freebsd");
+    let is_bsd = env::var("TARGET").unwrap().ends_with("bsd");
 
     // If we have the appropriate feature, then we build snappy.
     if have_snappy {
-        build_snappy(is_freebsd);
+        build_snappy(is_bsd);
     }
 
     // Copy the build_detect_platform file into the appropriate place.
@@ -178,7 +178,7 @@ fn main() {
     fs::set_permissions(&detect_path, perms).ok().expect("permissions could not be set");
 
     // Build LevelDB
-    build_leveldb(have_snappy, is_freebsd);
+    build_leveldb(have_snappy, is_bsd);
 
     // Print the appropriate linker flags
     let out_dir = env::var("OUT_DIR").ok().expect("OUT_DIR missing");


### PR DESCRIPTION
This patch will add support to FreeBSD.
The `build.rs` is recognizing FreeBSD using the TARGET environment variable, then configuring the build to use `gmake` instead of the incompatible `make`