### PR TITLE
Bsd fix link phase

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -121,7 +121,8 @@ fn main() {
     println!("[build] Started");
 
     let have_snappy = env::var("CARGO_FEATURE_SNAPPY").is_ok();
-    let is_bsd = env::var("TARGET").unwrap().ends_with("bsd");
+    let target = env::var("TARGET").unwrap();
+    let is_bsd = target.ends_with("bsd");
 
     // If we have the appropriate feature, then we build snappy.
     if have_snappy {
@@ -189,13 +190,10 @@ fn main() {
     };
     println!("cargo:rustc-flags=-L native={} {}", out_dir, linker_flags);
 
-    let target = env::var("TARGET").unwrap();
-    if target.contains("apple") {
+    if target.contains("apple") || target.contains("freebsd") {
         println!("cargo:rustc-link-lib=c++");
-    } else if target.contains("gnu") {
+    } else if target.contains("gnu") || target.contains("netbsd") || target.contains("openbsd") {
         println!("cargo:rustc-link-lib=stdc++");
-    } else if target.contains("bsd") {
-        println!("cargo:rustc-link-lib=c++");
     }
 
     println!("[build] Finished");

--- a/src/build.rs
+++ b/src/build.rs
@@ -194,6 +194,8 @@ fn main() {
         println!("cargo:rustc-link-lib=c++");
     } else if target.contains("gnu") {
         println!("cargo:rustc-link-lib=stdc++");
+    } else if target.contains("bsd") {
+        println!("cargo:rustc-link-lib=c++");
     }
 
     println!("[build] Finished");


### PR DESCRIPTION
Apparently the previous patch wasn't enough.
The linking phase on crates depending on this crate is now broken (on FreeBSD at least) because of missing symbols (c++ symbols).
I've tried to rework the final section of the `build.rs` in order to select the GNU `libstdc++` for *gnu* netBSD and openBSD (all based on `gcc`), while for apple and FreeBSD `libc++` is the library to use (based on Clang/LLVM).