### PR TITLE
Statically link against libstdc++ on musl targets

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -96,6 +96,10 @@ fn main() {
         println!("cargo:rustc-link-lib=c++");
     } else if target.contains("gnu") || target.contains("netbsd") || target.contains("openbsd") {
         println!("cargo:rustc-link-lib=stdc++");
+    } else if target.contains("musl") {
+        // We want to link to libstdc++ *statically*. This requires that the user passes the right
+        // search path to rustc via `-Lstatic=/path/to/libstdc++`.
+        println!("cargo:rustc-link-lib=static=stdc++");
     }
 
     println!("[build] Finished");


### PR DESCRIPTION
This makes it possible to use this crate on musl targets (but requires further external setup, since the library path has to be provided).