### PR TITLE
Fix CMake build for paths with single quotes and spaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ libc = "0.2.*"
 [build-dependencies]
 cmake = "0.1"
 num_cpus = "1.10"
+shell-escape = "0.1.5"

--- a/src/build.rs
+++ b/src/build.rs
@@ -24,13 +24,18 @@ fn build_snappy() -> PathBuf {
     let outdir = env::var("OUT_DIR").unwrap();
     let libdir = Path::new(&outdir).join(LIBDIR);
 
+    // Paths containing double quotes seem to break the CMake build.
+    if outdir.contains('"') {
+        panic!("can't build at path containing double quotes");
+    }
+
     env::set_var("NUM_JOBS", num_cpus::get().to_string());
     let dest_prefix =
         cmake::Config::new(Path::new("deps").join(format!("snappy-{}", SNAPPY_VERSION)))
             .define("BUILD_SHARED_LIBS", "OFF")
             .define("SNAPPY_BUILD_TESTS", "OFF")
             .define("HAVE_LIBZ", "OFF")
-            .define("CMAKE_INSTALL_LIBDIR", &libdir)
+            .define("CMAKE_INSTALL_LIBDIR", escape_path(&libdir))
             .build();
 
     assert_eq!(
@@ -49,6 +54,11 @@ fn build_leveldb(snappy_prefix: Option<PathBuf>) {
 
     let outdir = env::var("OUT_DIR").unwrap();
     let libdir = Path::new(&outdir).join(LIBDIR);
+
+    // Paths containing double quotes seem to break the CMake build.
+    if outdir.contains('"') {
+        panic!("can't build at path containing double quotes");
+    }
 
     env::set_var("NUM_JOBS", num_cpus::get().to_string());
     let mut config =


### PR DESCRIPTION
Currently, building `leveldb-sys` at a path with spaces in it fails with an error about the C compiler being unable to compile a simple program. I isolated the cause as the directory arguments to `-I` and `-L` being passed unquoted. Quoting them allows builds to succeed for project paths with spaces in them.

The issue only occurs when `snappy` is enabled, so to reproduce you need to:

1. Checkout `leveldb-sys` to a path name with spaces, e.g. `~/space dir/leveldb-sys`
2. Compile with `cargo build --features snappy`