### PR TITLE
Fix opaque types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leveldb-sys"
-version = "2.0.8"
+version = "2.0.9"
 authors = ["Andrew Dunham <andrew@du.nham.ca>", "Florian Gilcher <florian.gilcher@asquera.de>"]
 
 description = "FFI bindings to LevelDB"
@@ -16,6 +16,7 @@ snappy = []
 
 [dependencies]
 libc = "0.2.*"
+ffi-opaque = "0.1"
 
 [build-dependencies]
 cmake = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,23 +5,32 @@ extern crate libc;
 use libc::{c_char, c_int, c_uchar, c_void};
 use libc::size_t;
 
+macro_rules! opaque {
+    ($name:ident) => {
+        #[repr(C)]
+        pub struct $name {
+            _private: [u8; 0]
+        }
+    };
+}
+
 // These are opaque types that LevelDB uses.
-pub enum leveldb_t {}
-pub enum leveldb_cache_t {}
-pub enum leveldb_comparator_t {}
-pub enum leveldb_env_t {}
-pub enum leveldb_filelock_t {}
-pub enum leveldb_filterpolicy_t {}
-pub enum leveldb_iterator_t {}
-pub enum leveldb_logger_t {}
-pub enum leveldb_options_t {}
-pub enum leveldb_randomfile_t {}
-pub enum leveldb_readoptions_t {}
-pub enum leveldb_seqfile_t {}
-pub enum leveldb_snapshot_t {}
-pub enum leveldb_writablefile_t {}
-pub enum leveldb_writebatch_t {}
-pub enum leveldb_writeoptions_t {}
+opaque!(leveldb_t);
+opaque!(leveldb_cache_t);
+opaque!(leveldb_comparator_t);
+opaque!(leveldb_env_t);
+opaque!(leveldb_filelock_t);
+opaque!(leveldb_filterpolicy_t);
+opaque!(leveldb_iterator_t);
+opaque!(leveldb_logger_t);
+opaque!(leveldb_options_t);
+opaque!(leveldb_randomfile_t);
+opaque!(leveldb_readoptions_t);
+opaque!(leveldb_seqfile_t);
+opaque!(leveldb_snapshot_t);
+opaque!(leveldb_writablefile_t);
+opaque!(leveldb_writebatch_t);
+opaque!(leveldb_writeoptions_t);
 
 #[repr(C)]
 #[derive(Copy,Clone)]


### PR DESCRIPTION
This fixes a long-standing issue that was always a thorn in my side but did probably not impact anyone.

It replaces the pattern:

```rust
enum leveldb_t {}
```

With

```rust
#[repr(C)]
struct leveldb_t {
    _private: [u8; 0]
}
```

Which is the correct way to declare opaque types until [RFC 1861](https://github.com/rust-lang/rust/issues/43467) finally lands.

For that, it uses `ffi-opaque`.

Open question: is this semver-compatible?
